### PR TITLE
Fix genspec patch and output package

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -8,6 +8,11 @@ import os
 import shutil
 import re
 
+def copy_and_overwrite(from_path, to_path):
+    if os.path.exists(to_path):
+        shutil.rmtree(to_path)
+    shutil.copytree(from_path, to_path)
+
 def main():
   args = argument_parser(sys.argv[1:])
   with tempfile.TemporaryDirectory() as tmpdir:
@@ -18,6 +23,9 @@ def main():
 
     print(f'INFO: Loading schema and converting.')
     data = json.load(f)
+
+    scope_name = data["typeName"].split("::")[1].lower()
+    org_name = data["typeName"].split("::")[0].lower()
 
     result = {
       "ResourceTypes": {
@@ -67,31 +75,82 @@ def main():
     print('INFO: Running cfnspec bump to patch in custom resource.')
     os.system(f'cd {tmpdir}/aws-cdk; ./scripts/bump-cfnspec.sh')
 
-    print('INFO: Patching cfn2ts genspec to allow Generic prefix')
+    print(f'INFO: Patching cfn2ts genspec to allow {org_name.capitalize()} prefix')
     genspec_lines = ''
     genspec_path = f'{tmpdir}/aws-cdk/tools/cfn2ts/lib/genspec.js'
     with open(genspec_path, 'r') as inputfile:
       genspec_lines = inputfile.readlines()
     with open(genspec_path, 'w') as outputfile:
       for line in genspec_lines:
-        outputfile.write(re.sub(r"'AWS', 'Alexa'", "'AWS', 'Alexa', 'Generic'", line))
-
-    data["typeName"]
+        outputfile.write(re.sub(r"'AWS', 'Alexa'", f"'AWS', 'Alexa', '{org_name.capitalize()}'", line))
 
     print('INFO: Generating typescript with cfn2ts')
     os.system(f'cd {tmpdir}/aws-cdk/tools/cfn2ts; bin/cfn2ts --scope {data["typeName"].rsplit("::", 1)[0]}')
 
-    print('INFO: Copying final typescript')
-    scope_name = data["typeName"].split("::")[1].lower()
-    org_name = data["typeName"].split("::")[0].lower()
-    shutil.copytree(f'{tmpdir}/aws-cdk/packages/@aws-cdk/{org_name}-{scope_name}', f'{args.output_path}/{org_name}-{scope_name}')
-    shutil.copyfile(f'{tmpdir}/aws-cdk/tools/cfn2ts/lib/{scope_name}.generated.ts', f'{args.output_path}/{org_name}-{scope_name}/lib/{scope_name}.generated.ts')
+    print('INFO: Copying generated ts to package folder')
+    shutil.copyfile(f'{tmpdir}/aws-cdk/tools/cfn2ts/lib/{scope_name}.generated.ts', f'{tmpdir}/aws-cdk/packages/@aws-cdk/{org_name}-{scope_name}/lib/{scope_name}.generated.ts')
+
+    # print('INFO: Building package')
+    # os.system(f'cd {tmpdir}/aws-cdk/packages/@aws-cdk/{org_name}-{scope_name}; ../../../scripts/buildup')
+
+    print('INFO: Copying final package')
+    final_package_path = f'{args.output_path}/{data["typeName"].replace("::", "-").lower()}'
+    copy_and_overwrite(f'{tmpdir}/aws-cdk/packages/@aws-cdk/{org_name}-{scope_name}', final_package_path)
+
+    print('INFO: Will replace package.json in final package')
+    packagejson = {
+      "name": data["typeName"].replace("::", "-").lower(),
+      "version": args.version,
+      "description": f"The CDK Construct Library for {data['typeName']}",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "directories": {
+        "lib": "lib",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": args.author,
+      "license": "",
+      "dependencies": {
+        "@aws-cdk/core": args.cdkver
+      }
+    }
+    with open(f'{final_package_path}/package.json', 'w') as outfile:
+      json.dump(packagejson, outfile, indent=2)
+    
+    print('INFO: Generating tsconfig')
+    tsconfig = {
+      "compilerOptions": {
+        "target": "ES2017",
+        "module": "commonjs",
+        "declaration": True,
+        "outDir": "./dist",
+        "strict": True,
+        "esModuleInterop": True,
+        "skipLibCheck": True,
+        "forceConsistentCasingInFileNames": True
+      }
+    }
+    with open(f'{final_package_path}/tsconfig.json', 'w') as outfile:
+      json.dump(tsconfig, outfile, indent=2)
+
+    print('INFO: Cleaning up unused files')
+    shutil.rmtree(f'{final_package_path}/test')
+    os.remove(f'{final_package_path}/LICENSE')
+    os.remove(f'{final_package_path}/NOTICE')
+    os.remove(f'{final_package_path}/jest.config.js')
+    os.remove(f'{final_package_path}/.eslintrc.js')
 
 def argument_parser(cli_args, validate=True):
   parser = argparse.ArgumentParser(description="Convert CloudFormation Resource Provider Schema files (new spec) to Resource Specification files (old spec) which can then be converted to a AWS CDK TypeScript library with cfn2ts")
 
   parser.add_argument('--schema-url', '-u', help='The target schema file to convert.', required=True, dest='schema_url')
   parser.add_argument('--output-path', '-o', help='The output path.', default='./', dest='output_path')
+  parser.add_argument('--version', help='Version of the output package', default='0.1.0', dest='version')
+  parser.add_argument('--author', help='Package author', default='', dest='author')
+  parser.add_argument('--cdk-version', help='CDK package version for final package', default='^1.110.1', dest='cdkver')
 
   args, discard = parser.parse_known_args(cli_args)
 


### PR DESCRIPTION
The patch to fix the genspec file to accept other org names besides `AWS` and `Alexa` was hard coded for `Generic` but now uses the org name from the target schema. Closes #3

The default package output from `cfn2ts` was specifically built for packages inside the `aws-cdk` project. To support creation of an outside package the python code now creates its own `package.json` and `tsconfig.json` files. Not sure this is 100% correct as my typescript and javascript experience is limited but it seems to work. Closes #4